### PR TITLE
marvel_bins.py: Uncomment iteration setters.

### DIFF
--- a/marvel_bins.py
+++ b/marvel_bins.py
@@ -99,8 +99,8 @@ def extract_features(record):
                         non_coding_spacing.append(start - end_prev)
                         if strand_prev != feature.location.strand:
                             strand_shift += 1
-                    #end_prev = end
-                    #strand_prev = feature.location.strand
+                    end_prev = end
+                    strand_prev = feature.location.strand
             else:
                 print('WARNING: Prokka predicted a CDS, but there is no translation. Record ID: ',record.id)
 


### PR DESCRIPTION
Not sure why these lines were commented out - I was able to trace some odd results I was getting to those lines.

Also, unrelatedly, I found that marvel_bins.py did not work because a folder name was being given as the number of threads to prokka and hmmscan - this can be reproduced by just running it on some data.

Also, another small thing, hmmscan is not listed as a dependency in the README.

Hope that all helps. How come the "issues" tab on GitHub has been disabled? I almost did not submit the above comments because there was no obvious way to do so.

Thanks, ben