### PR TITLE
README: add scikit-learn dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ These Python libraries are required:
 
 * [Numpy](http://www.numpy.org/), [Scipy](https://www.scipy.org/) - Efficiently handling arrays and scientific computing
 * [Biopython](http://biopython.org/) - Handling biological sequences and records
+* [Scikit-learn](http://scikit-learn.org/stable/) - Machine learning
 
 To install these Python libraries, just type: 
 ```
-pip3 install -U numpy scipy biopython
+pip3 install -U numpy scipy biopython scikit-learn
 ```
 
 ## Installing


### PR DESCRIPTION
The README should mention that `scikit-learn` is also required as a dependency.

`marvel_bins.py` will crash without it:
```
Traceback (most recent call last):
  File "marvel_bins.py", line 287, in <module>
    pickle_model = pickle.load(file)
ModuleNotFoundError: No module named 'sklearn'
```